### PR TITLE
Fix of RSH, and subWithCarry modification

### DIFF
--- a/cpu.ts
+++ b/cpu.ts
@@ -278,7 +278,7 @@ class Rsh implements Instruction {
     }
 
     run(): void {
-        this.#regA.setUnsigned(this.#regC.getUnsigned() >> 1);
+        this.#regC.setUnsigned(this.#regA.getUnsigned() >> 1);
     }
 }
 

--- a/helpers.ts
+++ b/helpers.ts
@@ -35,10 +35,9 @@ export function addWithCarry(left: number, right: number): { carry: boolean, res
 }
 
 export function subWithCarry(left: number, right: number): { carry: boolean, result: number } {
-    const diff = left - right;
-
+    const diff = left + (toUnsigned(~right)) + 1;
     return {
-        carry: left >= right,
+        carry: diff > 0xFF,
         result: diff & 0xFF
     };
 }

--- a/helpers.ts
+++ b/helpers.ts
@@ -35,11 +35,7 @@ export function addWithCarry(left: number, right: number): { carry: boolean, res
 }
 
 export function subWithCarry(left: number, right: number): { carry: boolean, result: number } {
-    const diff = left + (toUnsigned(~right)) + 1;
-    return {
-        carry: diff > 0xFF,
-        result: diff & 0xFF
-    };
+    return addWithCarry(left, toUnsigned(~right) + 1);
 }
 
 export function checkRange(value: number) {


### PR DESCRIPTION
Fixes bug when RSH updates the wrong register and reads from the wrong register.
Also changes subWithCarry() to be more faithful to an actual adder circuit